### PR TITLE
Fix for Race condition in GetIPString #9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Nordix/ctraffic
 go 1.19
 
 require (
-	github.com/Nordix/mconnect/pkg/rndip/v2 v2.0.0-20210214133139-d0fb693d0599
+	github.com/Nordix/mconnect/pkg/rndip/v2 v2.0.0-20240902162515-1be1c6090854
 	github.com/brucespang/go-tcpinfo v0.0.0-20161205163524-e6cc7410d081
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Nordix/mconnect/pkg/rndip/v2 v2.0.0-20210214133139-d0fb693d0599 h1:fxFF22LN+tTb3B0Z0rVWw1gxfhQEGW72dLkOGmV1lcI=
-github.com/Nordix/mconnect/pkg/rndip/v2 v2.0.0-20210214133139-d0fb693d0599/go.mod h1:JbNTxVTSoYTxcm7PE9Ulg+lIDjti5Ek/tnIg635rKvI=
+github.com/Nordix/mconnect/pkg/rndip/v2 v2.0.0-20240902162515-1be1c6090854 h1:ePSC/+lD4w8GyjGEdqSK/Pc4a/MOXu1HFtDgQjpWy3Q=
+github.com/Nordix/mconnect/pkg/rndip/v2 v2.0.0-20240902162515-1be1c6090854/go.mod h1:JbNTxVTSoYTxcm7PE9Ulg+lIDjti5Ek/tnIg635rKvI=
 github.com/brucespang/go-tcpinfo v0.0.0-20161205163524-e6cc7410d081 h1:HvONGiFXAvZGq6y2lX/gUQOD0vfylQTjC7z5vNV8qCc=
 github.com/brucespang/go-tcpinfo v0.0.0-20161205163524-e6cc7410d081/go.mod h1:8a7quM0KlDusdd6l2h4LgIPMRVD4MRqHsilLl3sse5A=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5 h1:wjuX4b5yYQnEQHzd+CBcrcC6OVR2J1CN6mUy0oSxIPo=


### PR DESCRIPTION
The GetIPString method is replaced by GetIPStringIdx which gets the unique connection ID as a parameter that is used as index for the addresses array. This way one client will always try to get the address pointed by the ID which will avoid conflicts.